### PR TITLE
Remove sentence about voluntary military service

### DIFF
--- a/handbok/index.html
+++ b/handbok/index.html
@@ -236,7 +236,7 @@
 
           <section class="handbok" id="handbok-militaer">
             <h2>Militærtjeneste</h2>
-            <p>Innkalling til militærtjeneste, herunder førstegangstjeneste, som krever permisjon fra arbeidet varsles til personalansvarlig og legges i kalenderen. For pliktig tjeneste i Forsvaret, Heimevernet, Sivilforsvaret og Politireserven gis inntil en måned full lønn pr. år med fradrag av alle militære tillegg som lønn, dagpenger m.m. For frivillig tjeneste i Heimevernet gis permisjon uten lønn. For militær førstegangstjeneste gis permisjon uten lønn. Repetisjonsøvelser som har lengre varighet enn fire uker må avtales særskilt.</p>
+            <p>Innkalling til militærtjeneste, herunder førstegangstjeneste, som krever permisjon fra arbeidet varsles til personalansvarlig og legges i kalenderen. For tjeneste i Forsvaret, Heimevernet, Sivilforsvaret og Politireserven gis inntil en måned full lønn pr. år med fradrag av alle militære tillegg som lønn, dagpenger m.m. For militær førstegangstjeneste gis permisjon uten lønn. Repetisjonsøvelser som har lengre varighet enn fire uker må avtales særskilt.</p>
           </section>
 
           <section class="handbok" id="handbok-kommunikasjon">


### PR DESCRIPTION
Setningen om frivillig tjeneste er forvirrende fordi det er vanskelig å vite hva som går under begrepet frivillig tjeneste. De som er med innsatsstyrkene er frivillig medlem, men når de får en innkalling er de pliktig til å møte. Foreslår derfor å sløyfe setningen. 