### PR TITLE
Add missing translation to project page button

### DIFF
--- a/src/pages/dict.ts
+++ b/src/pages/dict.ts
@@ -13,6 +13,7 @@ export default {
     what: 'Hva gjør vi?',
     what_description:
       'Vi har utført prosjekter med og for kunder av varierende størrelse og på tvers av et bredt spekter av domener. Konsulentene våre sitter inne med mye kunnskap som vi gjerne deler med andre. Nedenfor finner du hvilke typer løsninger vi har utviklet for våre kunder.',
+    go_to_project_page_button: 'Les mer om prosjektet',
   },
   en: {
     people: 'Our Developers',
@@ -29,5 +30,6 @@ export default {
     what: 'Our Projects',
     what_description:
       'By adopting our value oriented approach we have carried out projects with and for clients of varying size, and across a wide spectrum of domains. Below you can find the types of solutions we have developed for our customers.',
+    go_to_project_page_button: 'Read more about the project',
   },
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -79,13 +79,13 @@ function Home(): JSX.Element {
           <h2 className="section-header-headline">
             {highlightedProject && fmt(highlightedProject.name, locale!)}
           </h2>
-          <p>{highlightedProject && fmt( highlightedProject.description, locale!)}</p>
+          <p>{highlightedProject && fmt(highlightedProject.description, locale!)}</p>
           <Button
             appearance={Button.appearances.DarkNoPadding}
             href={`/input/${highlightedProject && highlightedProject.urlName.toLowerCase()}`}
             disabled={!(highlightedProject && highlightedProject.published)}
           >
-            Go to project page
+            {t('go_to_project_page_button')}
           </Button>
         </div>
       </article>


### PR DESCRIPTION
Adds translation to the button for reading more about the different projects.

<img width="582" alt="Screenshot 2022-08-29 at 08 03 59" src="https://user-images.githubusercontent.com/9266175/187133859-962c0bf9-c744-4310-9caf-7c56c41d7b41.png">

<img width="569" alt="Screenshot 2022-08-29 at 08 03 38" src="https://user-images.githubusercontent.com/9266175/187133866-bcd28024-55f1-4329-8154-7c0c703828fb.png">


