### PR TITLE
Fix: landing people URL leads to people now

### DIFF
--- a/web/src/components/Landing/Konsulenter/index.tsx
+++ b/web/src/components/Landing/Konsulenter/index.tsx
@@ -63,7 +63,7 @@ const Konsulenter = ({ people }: { people: Person[] }) => {
         </div>
       </div>
       <div className="lg:mt-8 mt-4">
-          <Link href="/projects" className="green-link">
+          <Link href="/people" className="green-link">
             Se alle våre eksperter
           </Link>
       </div>


### PR DESCRIPTION
at the landing, the URL in the people section led to projects, not it leads to people