### PR TITLE
Remove pointer from menu bar

### DIFF
--- a/web/src/styles/_core.css
+++ b/web/src/styles/_core.css
@@ -220,7 +220,6 @@ ol {
   background-color: white;
   border: none;
   color: #000;
-  cursor: pointer;
   height: 44px;
   width: 100vw;
   position: fixed;


### PR DESCRIPTION
Removed the hand pointer from the menu bar. 
This made the hand pointer appear on the whole menu bar, and not just above the buttons. 

