### PR TITLE
Lagt til kodeworks analytics og en cookie conset event. Mangler conse…

### DIFF
--- a/web/src/components/useGtag.tsx
+++ b/web/src/components/useGtag.tsx
@@ -1,0 +1,93 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+const useGtag = () => {
+		const [isGtagLoaded, setIsGtagLoaded] = useState(false);
+    useEffect(() => {
+        // Ensure code runs only in the browser
+        if (typeof window !== 'undefined' && !isGtagLoaded) {
+					const scriptTag = document.getElementById('gtag');
+					if (!scriptTag) {
+						loadGtag();
+						console.log('Gtag loaded');
+						cookieConsentListener();
+						console.log('Cookie consent listener added');
+						setIsGtagLoaded(true);
+						// TODO Bytt ut med ekte cookie consent banner som trigger dispatchCookieConsentEvent basert på brukerens valg
+						setTimeout(() => {
+							dispatchCookieConsentEvent(ConsentStatus.GRANTED);
+						}, 5000);
+					}
+        }
+      }, []);
+
+
+      // Check if window exists, so it only runs on client side
+      function gtag(...args: any[]) {
+        window && window.dataLayer.push(args);
+      }
+
+			function loadGtag() {
+				const script = document.createElement('script');
+				script.id = 'gtag';
+				script.src = `https://www.googletagmanager.com/gtag/js?id=G-FLXYDD6Z0S`;
+				script.async = true;
+				script.onload = () => {
+					initializeGtag();
+					defaultConsent();
+				};
+				document.head.appendChild(script);
+
+			}
+
+			function cookieConsentListener() {
+				window.addEventListener('cookieConsent', (event: CustomEvent) => {
+					const consent = event.detail.consent;
+					console.log('Cookie consent event received: ', consent);
+					if (consent === 'granted') {
+						allConsentGranted();
+					}
+				});
+			}
+
+      function initializeGtag() {
+				window.dataLayer = window.dataLayer || [];
+        gtag('js', new Date());
+        gtag('config', 'G-FLXYDD6Z0S');
+      }
+
+      function defaultConsent() {
+        gtag('consent', 'default', {
+        'ad_storage': 'denied',
+        'ad_user_data': 'denied',
+        'ad_personalization': 'denied',
+        'analytics_storage': 'denied'
+        });
+      }
+
+      function allConsentGranted() {
+        gtag('consent', 'update', {
+          'ad_user_data': 'granted',
+          'ad_personalization': 'granted',
+          'ad_storage': 'granted',
+          'analytics_storage': 'granted'
+        });
+      }
+};
+
+
+export enum ConsentStatus {
+	GRANTED = 'granted',
+	DENIED = 'denied'
+}
+
+export const dispatchCookieConsentEvent = (status: ConsentStatus) => {
+	const event = new CustomEvent('cookieConsent', {
+		detail: {
+			consent: status
+		}
+	});
+	window.dispatchEvent(event);
+}
+
+export default useGtag;

--- a/web/src/components/useGtag.tsx
+++ b/web/src/components/useGtag.tsx
@@ -15,7 +15,7 @@ const useGtag = () => {
 						// TODO Bytt ut med ekte cookie consent banner som trigger dispatchCookieConsentEvent basert på brukerens valg
 						setTimeout(() => {
 							dispatchCookieConsentEvent(ConsentStatus.GRANTED);
-						}, 5000);
+						}, 2000);
 					}
         }
       }, []);

--- a/web/src/components/useGtag.tsx
+++ b/web/src/components/useGtag.tsx
@@ -11,7 +11,6 @@ const useGtag = () => {
 						loadGtag();
 						console.log('Gtag loaded');
 						cookieConsentListener();
-						console.log('Cookie consent listener added');
 						setIsGtagLoaded(true);
 						// TODO Bytt ut med ekte cookie consent banner som trigger dispatchCookieConsentEvent basert på brukerens valg
 						setTimeout(() => {
@@ -30,7 +29,7 @@ const useGtag = () => {
 			function loadGtag() {
 				const script = document.createElement('script');
 				script.id = 'gtag';
-				script.src = `https://www.googletagmanager.com/gtag/js?id=G-FLXYDD6Z0S`;
+				script.src = `https://www.googletagmanager.com/gtag/js?id=G-BRWDETNRQE`;
 				script.async = true;
 				script.onload = () => {
 					initializeGtag();

--- a/web/src/declaration.d.ts
+++ b/web/src/declaration.d.ts
@@ -7,3 +7,7 @@ declare module '*.png' {
     const value: string;
     export default value;
   }
+
+  interface Window {
+    dataLayer: any[];
+  }

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -13,6 +13,8 @@ import '../styles/kw.css';
 import { useTranslation } from '../utils/useTranslation';
 import Footer from '../components/Footer';
 import { Kontakt } from '../components/Landing';
+import useGtag from '../components/useGtag';
+
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -46,6 +48,8 @@ function Main(): JSX.Element {
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [scrollTop, setScrollTop] = useState(0);
   const router = useRouter();
+  // Add google analytics
+  useGtag();
 
   useEffect(() => {
     function onRouteChangeStart(): void {


### PR DESCRIPTION
Her må man legge til en consent banner slik at bruker kan velg om de aksepterer eller ikke. 

Når bruker aksepterer så er det lagd en enkel funksjon som heter `dispatchCookieConsentEvent` og kan importeres fra useGtag.tsx 

// Eksempel på en cookie consent banner
import { dispatchCookieConsentEvent, ConsentStatus } from '@/components/useGtag.tsx'; 

export default function ConsentBanner() {
 return (
   ....
   <button onClick={() => dispatchCookieConsentEvent(ConsentStatus.GRANTED}>Aksepter cookies </button>
 )
}